### PR TITLE
feat: add collection property to vtex and vtexLegacy ProductList loaders

### DIFF
--- a/commerce/vtex/client.ts
+++ b/commerce/vtex/client.ts
@@ -60,7 +60,7 @@ export const createClient = ({
   defaultHideUnnavailableItems = false,
 }: Partial<ConfigVTEX> = {}) => {
   const baseUrl =
-    `https://vtex-search-proxy.global.ssl.fastly.net/v2/${account}`;
+    `https://vtex-search-proxy.global.ssl.fastly.net/v2/${account}/`;
 
   const addDefaultFacets = (
     facets: SelectedFacet[],
@@ -115,7 +115,10 @@ export const createClient = ({
       .join("/");
 
     return fetchAPI(
-      `${baseUrl}/api/io/_v/api/intelligent-search/${type}/${pathname}?${params.toString()}`,
+      new URL(
+        `./api/io/_v/api/intelligent-search/${type}/${pathname}?${params.toString()}`,
+        baseUrl,
+      ).href,
     );
   };
 
@@ -131,7 +134,10 @@ export const createClient = ({
     });
 
     return fetchAPI(
-      `${baseUrl}/api/io/_v/api/intelligent-search/search_suggestions?${params.toString()}`,
+      new URL(
+        `./api/io/_v/api/intelligent-search/search_suggestions?${params.toString()}`,
+        baseUrl,
+      ).href,
     );
   };
 
@@ -143,7 +149,10 @@ export const createClient = ({
     });
 
     return fetchAPI(
-      `${baseUrl}/api/io/_v/api/intelligent-search/top_searches?${params.toString()}`,
+      new URL(
+        `./api/io/_v/api/intelligent-search/top_searches?${params.toString()}`,
+        baseUrl,
+      ).href,
     );
   };
 
@@ -172,7 +181,7 @@ export const createClient = ({
   ) => {
     const url = withLegacyParams(
       new URL(
-        `/api/catalog_system/pub/products/search/${term ?? ""}`,
+        `./api/catalog_system/pub/products/search/${term ?? ""}`,
         baseUrl,
       ),
       params,
@@ -188,7 +197,7 @@ export const createClient = ({
   ) => {
     const url = withLegacyParams(
       new URL(
-        `/api/catalog_system/pub/facets/search/${term ?? ""}`,
+        `./api/catalog_system/pub/facets/search/${term ?? ""}`,
         baseUrl,
       ),
       params,
@@ -199,7 +208,7 @@ export const createClient = ({
 
   const pageType = ({ slug }: { slug: string }) =>
     fetchAPI<PageType>(
-      `${baseUrl}/api/catalog_system/pub/portal/pagetype/${slug}`,
+      new URL(`./api/catalog_system/pub/portal/pagetype/${slug}`, baseUrl).href,
     );
 
   return {

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -471,6 +471,16 @@ const manifest: DecoManifest = {
             "title": "Sort",
             "description": "search sort parameter",
           },
+          "collection": {
+            "type": "array",
+            "items": {
+              "type": "string",
+            },
+            "title": "Collection",
+            "description":
+              "Collection ID or (Product Cluster id). For more info: https://developers.vtex.com/docs/api-reference/search-api#get-/api/catalog_system/pub/products/search .",
+            "pattern": "\\d*",
+          },
         },
         "required": [
           "query",
@@ -611,6 +621,16 @@ const manifest: DecoManifest = {
             ],
             "title": "Sort",
             "description": "search sort parameter",
+          },
+          "collection": {
+            "type": "array",
+            "items": {
+              "type": "string",
+            },
+            "title": "Collection",
+            "description":
+              "Collection ID or (Product Cluster id). For more info: https://developers.vtex.com/docs/api-reference/search-api#get-/api/catalog_system/pub/products/search .",
+            "pattern": "\\d*",
           },
         },
         "required": [

--- a/functions/occProductDetailsPage.ts
+++ b/functions/occProductDetailsPage.ts
@@ -12,10 +12,10 @@ import type { ProductDetailsPage } from "../commerce/types.ts";
 const productPageLoader: LoaderFunction<
   null,
   ProductDetailsPage | null,
-  LiveState<{ configocc: ConfigOCC }>
+  LiveState<{ configOCC: ConfigOCC }>
 > = async (_req, ctx) => {
-  const { configocc } = ctx.state.global;
-  const occ = createClient(configocc);
+  const { configOCC } = ctx.state.global;
+  const occ = createClient(configOCC);
 
   // search products on Oracle. Feel free to change any of these parameters
   const skuId = ctx.params.slug;

--- a/functions/shopifyProductDetailsPage.ts
+++ b/functions/shopifyProductDetailsPage.ts
@@ -12,13 +12,13 @@ import type { ProductDetailsPage } from "../commerce/types.ts";
 const productPageLoader: LoaderFunction<
   null,
   ProductDetailsPage | null,
-  LiveState<{ configshopify: ConfigShopify }>
+  LiveState<{ configShopify: ConfigShopify }>
 > = async (
   _req,
   ctx,
 ) => {
-  const { configshopify } = ctx.state.global;
-  const shopify = createClient(configshopify);
+  const { configShopify } = ctx.state.global;
+  const shopify = createClient(configShopify);
 
   const slug = ctx.params.slug;
   const splitted = slug?.split("-");

--- a/functions/shopifyProductList.ts
+++ b/functions/shopifyProductList.ts
@@ -19,14 +19,14 @@ export interface Props {
 const searchLoader: LoaderFunction<
   Props,
   Product[],
-  LiveState<{ configshopify: ConfigShopify }>
+  LiveState<{ configShopify: ConfigShopify }>
 > = async (
   _req,
   ctx,
   props,
 ) => {
-  const { configshopify } = ctx.state.global;
-  const shopify = createClient(configshopify);
+  const { configShopify } = ctx.state.global;
+  const shopify = createClient(configShopify);
 
   const count = props.count ?? 12;
   const query = props.query || "";

--- a/functions/shopifyProductListingPage.ts
+++ b/functions/shopifyProductListingPage.ts
@@ -24,15 +24,15 @@ export interface Props {
 const searchLoader: LoaderFunction<
   Props,
   ProductListingPage,
-  LiveState<{ configshopify: ConfigShopify }>
+  LiveState<{ configShopify: ConfigShopify }>
 > = async (
   req,
   ctx,
   props,
 ) => {
   const url = new URL(req.url);
-  const { configshopify } = ctx.state.global;
-  const shopify = createClient(configshopify);
+  const { configShopify } = ctx.state.global;
+  const shopify = createClient(configShopify);
 
   const count = props.count ?? 12;
   const query = props.query || url.searchParams.get("q") || "";

--- a/functions/vtexLegacyProductDetailsPage.ts
+++ b/functions/vtexLegacyProductDetailsPage.ts
@@ -12,13 +12,13 @@ import type { ProductDetailsPage } from "../commerce/types.ts";
 const legacyProductPageLoader: LoaderFunction<
   null,
   ProductDetailsPage | null,
-  LiveState<{ configvtex: ConfigVTEX | undefined }>
+  LiveState<{ configVTEX: ConfigVTEX | undefined }>
 > = async (
   req,
   ctx,
 ) => {
-  const { configvtex } = ctx.state.global;
-  const vtex = createClient(configvtex);
+  const { configVTEX } = ctx.state.global;
+  const vtex = createClient(configVTEX);
   const url = new URL(req.url);
   const skuId = url.searchParams.get("skuId");
 

--- a/functions/vtexLegacyProductList.ts
+++ b/functions/vtexLegacyProductList.ts
@@ -41,14 +41,15 @@ export interface Props {
 const legacyProductListLoader: LoaderFunction<
   Props,
   Product[],
-  LiveState<{ configvtex: ConfigVTEX | undefined }>
+  LiveState<{ configVTEX: ConfigVTEX | undefined }>
 > = async (
   req,
   ctx,
   props,
 ) => {
-  const { configvtex } = ctx.state.global;
-  const vtex = createClient(configvtex);
+  const { configVTEX } = ctx.state.global;
+  console.log("Config vtex", ctx.state.global);
+  const vtex = createClient(configVTEX);
   const url = new URL(req.url);
 
   const count = props.count ?? 12;

--- a/functions/vtexLegacyProductListingPage.ts
+++ b/functions/vtexLegacyProductListingPage.ts
@@ -108,15 +108,15 @@ const mapParamFromUrl = (pages: PageType[]) =>
 const legacyPLPLoader: LoaderFunction<
   Props,
   ProductListingPage,
-  LiveState<{ configvtex?: ConfigVTEX }>
+  LiveState<{ configVTEX?: ConfigVTEX }>
 > = async (
   req,
   ctx,
   props,
 ) => {
   const url = new URL(req.url);
-  const { configvtex } = ctx.state.global;
-  const vtex = createClient(configvtex);
+  const { configVTEX } = ctx.state.global;
+  const vtex = createClient(configVTEX);
 
   const count = props.count ?? 12;
   const term = props.term || ctx.params["0"] || "";

--- a/functions/vtexProductDetailsPage.ts
+++ b/functions/vtexProductDetailsPage.ts
@@ -12,15 +12,15 @@ import type { ProductDetailsPage } from "../commerce/types.ts";
 const productPageLoader: LoaderFunction<
   null,
   ProductDetailsPage | null,
-  LiveState<{ configvtex: ConfigVTEX | undefined }>
+  LiveState<{ configVTEX: ConfigVTEX | undefined }>
 > = async (
   req,
   ctx,
 ) => {
   const url = new URL(req.url);
   const skuId = url.searchParams.get("skuId");
-  const { configvtex } = ctx.state.global;
-  const vtex = createClient(configvtex);
+  const { configVTEX } = ctx.state.global;
+  const vtex = createClient(configVTEX);
 
   // search products on VTEX. Feel free to change any of these parameters
   const { products: [product] } = await vtex.search.products({

--- a/functions/vtexProductList.ts
+++ b/functions/vtexProductList.ts
@@ -40,14 +40,14 @@ export interface Props {
 const productListLoader: LoaderFunction<
   Props,
   Product[],
-  LiveState<{ configvtex: ConfigVTEX | undefined }>
+  LiveState<{ configVTEX: ConfigVTEX | undefined }>
 > = async (
   req,
   ctx,
   props,
 ) => {
-  const { configvtex } = ctx.state.global;
-  const vtex = createClient(configvtex);
+  const { configVTEX } = ctx.state.global;
+  const vtex = createClient(configVTEX);
   const url = new URL(req.url);
 
   const count = props.count ?? 12;

--- a/functions/vtexProductList.ts
+++ b/functions/vtexProductList.ts
@@ -4,7 +4,7 @@ import type { LiveState } from "$live/types.ts";
 import { toProduct } from "../commerce/vtex/transform.ts";
 import { ConfigVTEX, createClient } from "../commerce/vtex/client.ts";
 import type { Product } from "../commerce/types.ts";
-import type { Sort } from "../commerce/vtex/types.ts";
+import type { SearchArgs, Sort } from "../commerce/vtex/types.ts";
 
 export interface Props {
   /** @description query to use on search */
@@ -24,6 +24,13 @@ export interface Props {
     | "name:asc"
     | "release:desc"
     | "discount:desc";
+
+  // TODO: pattern property isn't being handled by RJSF
+  /**
+   * @description Collection ID or (Product Cluster id). For more info: https://developers.vtex.com/docs/api-reference/search-api#get-/api/catalog_system/pub/products/search .
+   * @pattern \d*
+   */
+  collection?: string[];
 }
 
 /**
@@ -46,6 +53,16 @@ const productListLoader: LoaderFunction<
   const count = props.count ?? 12;
   const query = props.query || "";
   const sort: Sort = props.sort || "";
+  const selectedFacets: SearchArgs["selectedFacets"] = [];
+
+  if (props.collection) {
+    props.collection.forEach((productClusterId) => {
+      selectedFacets.push({
+        key: "productClusterIds",
+        value: productClusterId,
+      });
+    });
+  }
 
   // search products on VTEX. Feel free to change any of these parameters
   const { products: vtexProducts } = await vtex.search.products({
@@ -53,6 +70,7 @@ const productListLoader: LoaderFunction<
     page: 0,
     count,
     sort,
+    selectedFacets,
   });
 
   // Transform VTEX product format into schema.org's compatible format

--- a/functions/vtexProductListingPage.ts
+++ b/functions/vtexProductListingPage.ts
@@ -67,15 +67,15 @@ const filtersFromPathname = (pages: PageType[]) =>
 const plpLoader: LoaderFunction<
   Props,
   ProductListingPage,
-  LiveState<{ configvtex?: ConfigVTEX }>
+  LiveState<{ configVTEX?: ConfigVTEX }>
 > = async (
   req,
   ctx,
   props,
 ) => {
-  const { configvtex } = ctx.state.global;
+  const { configVTEX } = ctx.state.global;
   const url = new URL(req.url);
-  const vtex = createClient(configvtex);
+  const vtex = createClient(configVTEX);
 
   const count = props.count ?? 12;
   const query = props.query || url.searchParams.get("q") || "";


### PR DESCRIPTION
This PR adds the collection parameter to vtexLegacyProductList and vtexProductList. According to the VTEX documentation a collection and productClusterId is equivalent, so this PR adds the productClusterIds to the search requests.

Example using product clusters:
- intelligent search: as facet https://decopartnerbr.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/productClusterIds/137
- Search API: as fq querystring https://decopartnerbr.vtexcommercestable.com.br/api/catalog_system/pub/products/search/jeans?fq=productClusterIds:137

This PR fixes:
- vtexLegacyProductList indexes from=0 to=count-1 because the vtex search API is indexed by 0;
- fix the configVTEX, configShopify and configOCC at respective loaders.
- Fix vtex client to use proxy path `/v2/account/...(path)`