### PR TITLE
feat: add YourViews loader function

### DIFF
--- a/commerce/occ/transform.ts
+++ b/commerce/occ/transform.ts
@@ -40,6 +40,7 @@ export const toProductPage = (
   stock: ProductSkuInventoryStatus,
 ): ProductDetailsPage => {
   return {
+    "@type": "ProductDetailsPage",
     breadcrumbList: toBreadcrumbList(product),
     product: toProduct(product, stock),
   };

--- a/commerce/shopify/transform.ts
+++ b/commerce/shopify/transform.ts
@@ -51,6 +51,7 @@ export const toProductPage = (
   }
 
   return {
+    "@type": "ProductDetailsPage",
     breadcrumbList: toBreadcrumbList(product, sku),
     product: toProduct(product, sku),
   };

--- a/commerce/types.ts
+++ b/commerce/types.ts
@@ -65,6 +65,8 @@ export interface AggregateRating {
   ratingCount?: number;
   /** The count of total number of reviews. */
   reviewCount?: number;
+  /** The rating for the content. */
+  ratingValue?: number;
 }
 
 export declare type ItemAvailability =
@@ -336,11 +338,13 @@ export interface FilterRange extends FilterBase {
 export type Filter = FilterToggle | FilterRange;
 
 export interface ProductDetailsPage {
+  "@type": "ProductDetailsPage";
   breadcrumbList: BreadcrumbList;
   product: Product;
 }
 
 export interface ProductListingPage {
+  "@type": "ProductListingPage";
   breadcrumb: BreadcrumbList;
   filters: Filter[];
   products: Product[];

--- a/commerce/vtex/transform.ts
+++ b/commerce/vtex/transform.ts
@@ -72,6 +72,7 @@ export const toProductPage = (
   }
 
   return {
+    "@type": "ProductDetailsPage",
     breadcrumbList: toBreadcrumbList(product, sku, options),
     product: toProduct(product, sku, 0, options),
   };

--- a/commerce/yourViews/client.ts
+++ b/commerce/yourViews/client.ts
@@ -1,0 +1,89 @@
+import { fetchAPI } from "../../utils/fetchAPI.ts";
+import { Ratings, Reviews } from "./types.ts";
+
+export type ClientYourViews = ReturnType<typeof createClient>;
+
+export interface ConfigYourViews {
+  token: string;
+  appId: string;
+}
+
+export interface PaginationOptions {
+  page?: number;
+  count?: number;
+}
+
+const baseUrl = "http://service.yourviews.com.br";
+
+export const createClient = ({ token, appId }: ConfigYourViews) => {
+  const headers = {
+    "Authorization": token,
+  };
+
+  /** @description https://yourviews.freshdesk.com/support/solutions/articles/5000756179-buscar-as-estrelas-nas-prateleiras */
+  const rating = (
+    { page = 0, count = 1, productId }: PaginationOptions & {
+      productId: string;
+    },
+  ) =>
+    fetchAPI<Ratings>(
+      `${baseUrl}/api/${appId}/review/reviewshelf?${new URLSearchParams(
+        { page, count, productIds: productId } as unknown as Record<
+          string,
+          string
+        >,
+      )}`,
+      { headers },
+    );
+
+  /** @description https://yourviews.freshdesk.com/support/solutions/articles/5000756179-buscar-as-estrelas-nas-prateleiras */
+  const ratings = (
+    { page = 0, count, productIds }: PaginationOptions & {
+      productIds: string[];
+    },
+  ) =>
+    fetchAPI<Ratings>(
+      `${baseUrl}/api/${appId}/review/reviewshelf?${new URLSearchParams({
+        page,
+        count: count ?? productIds.length,
+        productIds: productIds.join(","),
+      } as unknown as Record<string, string>)}`,
+      { headers },
+    );
+
+  /** @description https://yourviews.freshdesk.com/support/solutions/articles/5000740469-buscar-reviews-de-produto */
+  const review = (
+    { reviewId, ...params }: PaginationOptions & { reviewId: string },
+  ) =>
+    fetchAPI<Reviews>(
+      `${baseUrl}/api/${appId}/review/${reviewId}?${new URLSearchParams(
+        params as unknown as Record<string, string>,
+      )}`,
+      {
+        headers,
+      },
+    );
+
+  /** @description https://yourviews.freshdesk.com/support/solutions/articles/5000740469-buscar-reviews-de-produto */
+  const reviews = (
+    options: PaginationOptions & {
+      productId: string;
+      orderBy: number;
+    },
+  ) =>
+    fetchAPI<Reviews>(
+      `${baseUrl}/api/${appId}/review?${new URLSearchParams(
+        options as unknown as Record<string, string>,
+      )}`,
+      {
+        headers,
+      },
+    );
+
+  return {
+    rating,
+    ratings,
+    review,
+    reviews,
+  };
+};

--- a/commerce/yourViews/types.ts
+++ b/commerce/yourViews/types.ts
@@ -1,0 +1,52 @@
+export interface Ratings {
+  HasErrors: boolean;
+  Element: Rating[];
+  ErrorList: unknown[];
+  Total: number;
+  CurrentPage: number;
+}
+
+export interface Rating {
+  ProductId: string;
+  TotalRatings: number;
+  Rating: number;
+}
+
+export interface Reviews {
+  HasErrors: boolean;
+  Element: Review[];
+  ErrorList: unknown[];
+  Total: number;
+  CurrentPage: number;
+}
+
+export interface Review {
+  ReviewId: number;
+  Rating: number;
+  Review: string;
+  Date: Date;
+  User: User;
+  Product: Product;
+  Likes: number;
+  Dislikes: number;
+  CustomFields: CustomField[];
+}
+
+export interface CustomField {
+  Name: string;
+  Values: string[];
+}
+
+export interface Product {
+  YourviewsProductId: number;
+  ProductId: string;
+  Name: string;
+  Url: string;
+  Image: string;
+}
+
+export interface User {
+  YourviewsUserId: number;
+  Name: string;
+  Email: string;
+}

--- a/commerce/yourViews/withYourViews.ts
+++ b/commerce/yourViews/withYourViews.ts
@@ -1,0 +1,95 @@
+import type { LiveState, LoaderFunction } from "$live/types.ts";
+import type {
+  Product,
+  ProductDetailsPage,
+  ProductListingPage,
+} from "../types.ts";
+import { ConfigYourViews, createClient } from "./client.ts";
+import type { Ratings } from "./types.ts";
+
+export const addRatingsToProduct =
+  (ratings: Ratings) => (product: Product): Product => {
+    const productId = getProductId(product);
+    const rating = ratings.Element.find((rating) =>
+      rating.ProductId === productId
+    );
+
+    return {
+      ...product,
+      aggregateRating: rating
+        ? {
+          "@type": "AggregateRating",
+          ratingCount: rating.TotalRatings,
+          ratingValue: rating.Rating,
+        }
+        : undefined,
+    };
+  };
+
+const getProductId = (product: Product) => product.isVariantOf!.productGroupID;
+
+export const withYourViews = <
+  Props,
+  Data extends ProductDetailsPage | Product[] | ProductListingPage | null,
+  State extends LiveState<{ configYourViews: ConfigYourViews | undefined }>,
+>(
+  loader: LoaderFunction<Props, Data, State>,
+): LoaderFunction<Props, Data, State> =>
+async (req, ctx, props) => {
+  const response = await loader(req, ctx, props);
+
+  if (response.data == null) {
+    return response;
+  }
+
+  if (!ctx.state.global.configYourViews) {
+    console.error(
+      "Missing configuration from YourViews instegration. Open Deco admin and set YourViews appId and token on global sections at Library",
+    );
+
+    return response;
+  }
+
+  const client = createClient(ctx.state.global.configYourViews);
+
+  if (Array.isArray(response.data)) {
+    const productIds = response.data.map(getProductId);
+
+    const ratings = await client.ratings({ productIds });
+
+    return {
+      ...response,
+      data: response.data.map(addRatingsToProduct(ratings)) as Data,
+    };
+  }
+
+  if (response.data["@type"] === "ProductDetailsPage") {
+    const productId = getProductId(response.data.product);
+
+    const ratings = await client.rating({ productId });
+
+    return {
+      ...response,
+      data: {
+        ...response.data,
+        product: addRatingsToProduct(ratings)(response.data.product),
+      },
+    };
+  }
+
+  if (response.data["@type"] === "ProductListingPage") {
+    const productIds = response.data.products.map(getProductId);
+
+    const ratings = await client.ratings({ productIds });
+
+    return {
+      ...response,
+      data: {
+        ...response.data,
+        products: response.data.products.map(addRatingsToProduct(ratings)),
+      },
+    };
+  }
+
+  return response;
+};

--- a/commerce/yourViews/withYourViews.ts
+++ b/commerce/yourViews/withYourViews.ts
@@ -31,10 +31,10 @@ const getProductId = (product: Product) => product.isVariantOf!.productGroupID;
 export const withYourViews = <
   Props,
   Data extends ProductDetailsPage | Product[] | ProductListingPage | null,
-  State extends LiveState<{ configYourViews: ConfigYourViews | undefined }>,
+  Global extends { configYourViews: ConfigYourViews | undefined },
 >(
-  loader: LoaderFunction<Props, Data, State>,
-): LoaderFunction<Props, Data, State> =>
+  loader: LoaderFunction<Props, Data, LiveState<Global>>,
+): LoaderFunction<Props, Data, LiveState<Global>> =>
 async (req, ctx, props) => {
   const response = await loader(req, ctx, props);
 

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -16,6 +16,7 @@ import * as $$$2 from "./sections/SEOPLP.tsx";
 import * as $$$3 from "./sections/configOCC.global.tsx";
 import * as $$$4 from "./sections/configShopify.global.tsx";
 import * as $$$5 from "./sections/configVTEX.global.tsx";
+import * as $$$6 from "./sections/configYourViews.tsx";
 import * as $$$$0 from "./functions/occProductDetailsPage.ts";
 import * as $$$$1 from "./functions/shopifyProductDetailsPage.ts";
 import * as $$$$2 from "./functions/shopifyProductList.ts";
@@ -50,6 +51,7 @@ const manifest: DecoManifest = {
     "./sections/configOCC.global.tsx": $$$3,
     "./sections/configShopify.global.tsx": $$$4,
     "./sections/configVTEX.global.tsx": $$$5,
+    "./sections/configYourViews.tsx": $$$6,
   },
   functions: {
     "./functions/occProductDetailsPage.ts": $$$$0,
@@ -308,6 +310,10 @@ const manifest: DecoManifest = {
           "defaultSalesChannel",
         ],
       },
+      "outputSchema": null,
+    },
+    "./sections/configYourViews.tsx": {
+      "inputSchema": null,
       "outputSchema": null,
     },
     "./functions/occProductDetailsPage.ts": {

--- a/functions/shopifyProductListingPage.ts
+++ b/functions/shopifyProductListingPage.ts
@@ -66,6 +66,7 @@ const searchLoader: LoaderFunction<
 
   return {
     data: {
+      "@type": "ProductListingPage",
       // TODO: Find out what's the right breadcrumb on shopify
       breadcrumb: {
         "@type": "BreadcrumbList",

--- a/functions/vtexLegacyProductListingPage.ts
+++ b/functions/vtexLegacyProductListingPage.ts
@@ -181,7 +181,7 @@ const legacyPLPLoader: LoaderFunction<
 
   return {
     data: {
-      '@type': 'ProductListingPage',
+      "@type": "ProductListingPage",
       breadcrumb: {
         "@type": "BreadcrumbList",
         itemListElement,

--- a/functions/vtexLegacyProductListingPage.ts
+++ b/functions/vtexLegacyProductListingPage.ts
@@ -181,6 +181,7 @@ const legacyPLPLoader: LoaderFunction<
 
   return {
     data: {
+      '@type': 'ProductListingPage',
       breadcrumb: {
         "@type": "BreadcrumbList",
         itemListElement,

--- a/functions/vtexProductListingPage.ts
+++ b/functions/vtexProductListingPage.ts
@@ -133,6 +133,7 @@ const plpLoader: LoaderFunction<
 
   return {
     data: {
+      "@type": "ProductListingPage",
       breadcrumb: {
         "@type": "BreadcrumbList",
         itemListElement,

--- a/sections/configYourViews.tsx
+++ b/sections/configYourViews.tsx
@@ -1,0 +1,12 @@
+import type { ConfigVTEX } from "../commerce/vtex/client.ts";
+
+function ConfigSection(_: ConfigVTEX) {
+  return (
+    <div>
+      "This is a global setting and not a component. Every change here will
+      impact all environments, published/archived/draft"
+    </div>
+  );
+}
+
+export default ConfigSection;

--- a/sections/configYourViews.tsx
+++ b/sections/configYourViews.tsx
@@ -1,6 +1,6 @@
-import type { ConfigVTEX } from "../commerce/vtex/client.ts";
+import type { ConfigYourViews } from "../commerce/yourviews/client.ts";
 
-function ConfigSection(_: ConfigVTEX) {
+function ConfigSection(_: ConfigYourViews) {
   return (
     <div>
       "This is a global setting and not a component. Every change here will


### PR DESCRIPTION
This PR adds the YourViews client and loader functions so users may use yourViews ratings in their frontned

## Usage
To use yourViews, your need to create a new loader on your website, one for each page type, and wrap it under the `withYourViews` function. For instance, to create a PDPLoader, create the file and add the following code:
```ts
import type { LoaderFunction } from "$live/types.ts";
import type { LiveState } from "$live/types.ts";

import { ConfigVTEX } from "../commerce/vtex/client.ts";
import { withYourViews } from "../commerce/yourViews/withYourViews.ts";
import productPageLoader from "./vtexProductDetailsPage.ts";
import { ConfigYourViews } from "../commerce/yourViews/client.ts";
import type { ProductDetailsPage } from "../commerce/types.ts";

/**
 * @title VTEX Product Page Loader
 * @description Works on routes of type /:slug/p
 */
const pdpLoader: LoaderFunction<
  null,
  ProductDetailsPage | null,
  LiveState<
    {
      configVTEX: ConfigVTEX | undefined;
      configYourViews: ConfigYourViews | undefined;
    }
  >
> = withYourViews<
  null,
  ProductDetailsPage | null,
  {
    configVTEX: ConfigVTEX | undefined;
    configYourViews: ConfigYourViews | undefined;
  }
>(productPageLoader);

export default pdpLoader;

```

Now, the loaders should be visible on admin and the products should all come with ratings stars on the property "aggregateRating" of the product