### PR TITLE
fix: navbar urls

### DIFF
--- a/commerce/vtex/transform.ts
+++ b/commerce/vtex/transform.ts
@@ -414,8 +414,10 @@ export const toFilter = (
 };
 
 function nodeToNavbar(node: Category): Navbar {
+  const url = new URL(node.url, "https://example.com");
+
   return {
-    href: node.url,
+    href: `${url.pathname}${url.search}`,
     label: node.name,
     children: node.children.map(nodeToNavbar),
   };


### PR DESCRIPTION
This PR removes the domain from the navbar loader.

Before: 
```js
{
  data: [
    {
      href: "https://bravtexfashionstore.vtexcommercestable.com.br/masculino",
      label: "Masculino",
      children: []
    },
    {
      href: "https://bravtexfashionstore.vtexcommercestable.com.br/feminino",
      label: "Feminino",
      children: [ [Object] ]
    },
    {
      href: "https://bravtexfashionstore.vtexcommercestable.com.br/brindes",
      label: "Brindes",
      children: []
    }
  ]
}
```

After:
```js
{
  data: [
    { href: "/masculino", label: "Masculino", children: [] },
    { href: "/feminino", label: "Feminino", children: [ [Object] ] },
    { href: "/brindes", label: "Brindes", children: [] }
  ]
}
```