### PR TITLE
feat: Nullable height for image componente

### DIFF
--- a/components/Image.tsx
+++ b/components/Image.tsx
@@ -7,7 +7,7 @@ type Props =
   & Omit<JSX.IntrinsicElements["img"], "width" | "height" | "preload">
   & {
     width: number;
-    height: number;
+    height?: number;
     src: string;
     preload?: boolean;
     fetchPriority?: "high" | "low" | "auto";
@@ -19,7 +19,7 @@ const imageKit = new ImageKit({
 
 const FACTORS = [1, 1.5, 2];
 
-export const getSrcSet = (src: string, width: number, height: number) =>
+export const getSrcSet = (src: string, width: number, height?: number) =>
   FACTORS
     .map((factor) =>
       `${
@@ -27,7 +27,7 @@ export const getSrcSet = (src: string, width: number, height: number) =>
           path: src,
           transformation: [{
             width: `${Math.trunc(factor * width)}`,
-            height: `${Math.trunc(factor * height)}`,
+            ...(height ? { height: `${Math.trunc(factor * height)}` } : {}),
           }],
         })
       } ${Math.trunc(factor * width)}w`

--- a/components/Image.tsx
+++ b/components/Image.tsx
@@ -27,7 +27,7 @@ export const getSrcSet = (src: string, width: number, height?: number) =>
           path: src,
           transformation: [{
             width: `${Math.trunc(factor * width)}`,
-            ...(height ? { height: `${Math.trunc(factor * height)}` } : {}),
+            height: height ? `${Math.trunc(factor * height)}` : undefined,
           }],
         })
       } ${Math.trunc(factor * width)}w`

--- a/components/Picture.tsx
+++ b/components/Picture.tsx
@@ -18,7 +18,7 @@ type SourceProps =
   & {
     src: string;
     width: number;
-    height: number;
+    height?: number;
     preload?: boolean;
     fetchPriority?: "high" | "low" | "auto";
   };


### PR DESCRIPTION
Solves #22 

Example:
this base image: https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/5ff739e6-0e3b-4f6a-b562-aed7399a90e8

this image has naturalWidth: 4320 and naturalHeight: 1800 - aspect ratio: 0.4166666666666667 

base image output from service image without height dimension: https://ik.imagekit.io/decocx/tr:w-1440,h-/https:/ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/5ff739e6-0e3b-4f6a-b562-aed7399a90e8

this image has naturalWidth: 1440 (from URL width) and naturalHeight: 600 -  aspect ratio: 0.4166666666666667