### PR TITLE
Fixing category property and adding for clusters

### DIFF
--- a/commerce/vtex/types.ts
+++ b/commerce/vtex/types.ts
@@ -629,7 +629,12 @@ export interface IProduct {
   releaseDate: string;
 }
 
-export type Product = IProduct & { items: Item[]; origin?: string };
+export type Product = IProduct & {
+  items: Item[];
+  origin?: string;
+  clusterHighlights: Array<{ id: string; name: string }>;
+  productClusters: Array<{ id: string; name: string }>;
+};
 
 export type LegacyProduct = IProduct & {
   items: LegacyItem[];


### PR DESCRIPTION
Also fixes types for `productClusters` and `clusterHighlights` since they come differently:

![image](https://user-images.githubusercontent.com/18706156/230664111-5b8af1a7-164b-4bde-9457-3ef5580ba0c2.png)
![image](https://user-images.githubusercontent.com/18706156/230664154-63c0a342-e1ec-42a2-8d50-6a25a829b363.png)


![image](https://user-images.githubusercontent.com/18706156/230663358-9ac01e5f-1b5f-4c6e-b873-aa178608e17b.png)
![image](https://user-images.githubusercontent.com/18706156/230663377-4685fa5b-1a9a-473a-8399-8789279046d3.png)
