### PR TITLE
feat: decocache

### DIFF
--- a/commerce/vnda/client.ts
+++ b/commerce/vnda/client.ts
@@ -11,10 +11,8 @@ import {
 } from "./types.ts";
 
 const DOMAIN_HEADER = "X-Shop-Host";
-const BASE_URL_PROD =
-  "https://proxy.decocache.com/https://api.vnda.com.br/api/v2/";
-const BASE_URL_SANDBOX =
-  "https://proxy.decocache.com/https://api.sandbox.vnda.com.br/api/v2/";
+const BASE_URL_PROD = "https://api.vnda.com.br/api/v2/";
+const BASE_URL_SANDBOX = "https://api.sandbox.vnda.com.br/api/v2/";
 
 export const VNDA_SORT_OPTIONS: SortOption[] = [
   { value: "", label: "Relevância" },
@@ -30,12 +28,13 @@ export const createClient = (params: ConfigVNDA) => {
 
   const fetcher = <T>(
     endpoint: string,
-    method?: string,
+    method = "GET",
     data?: Record<string, unknown>,
   ) => {
     return fetchAPI<T>(new URL(endpoint, baseUrl), {
       body: data ? JSON.stringify(data) : undefined,
-      method: method ?? "GET",
+      method,
+      withProxyCache: method === "GET",
       headers: {
         [DOMAIN_HEADER]: domain,
         accept: "application/json",

--- a/commerce/vnda/client.ts
+++ b/commerce/vnda/client.ts
@@ -11,8 +11,10 @@ import {
 } from "./types.ts";
 
 const DOMAIN_HEADER = "X-Shop-Host";
-const BASE_URL_PROD = "https://api.vnda.com.br/api/v2/";
-const BASE_URL_SANDBOX = "https://api.sandbox.vnda.com.br/api/v2/";
+const BASE_URL_PROD =
+  "https://proxy.decocache.com/https://api.vnda.com.br/api/v2/";
+const BASE_URL_SANDBOX =
+  "https://proxy.decocache.com/https://api.sandbox.vnda.com.br/api/v2/";
 
 export const VNDA_SORT_OPTIONS: SortOption[] = [
   { value: "", label: "Relevância" },
@@ -31,7 +33,7 @@ export const createClient = (params: ConfigVNDA) => {
     method?: string,
     data?: Record<string, unknown>,
   ) => {
-    return fetchAPI<T>(new URL(endpoint, baseUrl).href, {
+    return fetchAPI<T>(new URL(endpoint, baseUrl), {
       body: data ? JSON.stringify(data) : undefined,
       method: method ?? "GET",
       headers: {

--- a/commerce/vtex/client.ts
+++ b/commerce/vtex/client.ts
@@ -95,9 +95,8 @@ export const createClient = ({
   defaultLocale = "en-US",
   defaultHideUnnavailableItems = false,
 }: Partial<ConfigVTEX> = {}) => {
-  const decoAPIUrl =
-    `https://vtex-search-proxy.global.ssl.fastly.net/v2/${account}/`;
   const vtexAPIUrl = `https://${account}.vtexcommercestable.com.br`;
+  const decoAPIUrl = `https://proxy.decocache.com/${vtexAPIUrl}/`;
   const withCache = window.location?.origin
     ? window.location.origin
     : decoAPIUrl;

--- a/commerce/yourViews/client.ts
+++ b/commerce/yourViews/client.ts
@@ -13,7 +13,7 @@ export interface PaginationOptions {
   count?: number;
 }
 
-const baseUrl = "http://proxy.decocache.com/http://service.yourviews.com.br";
+const baseUrl = "http://service.yourviews.com.br";
 
 export const createClient = ({ token, appId }: ConfigYourViews) => {
   const headers = {
@@ -33,7 +33,7 @@ export const createClient = ({ token, appId }: ConfigYourViews) => {
           string
         >,
       )}`,
-      { headers },
+      { headers, withProxyCache: true },
     );
 
   /** @description https://yourviews.freshdesk.com/support/solutions/articles/5000756179-buscar-as-estrelas-nas-prateleiras */
@@ -48,7 +48,7 @@ export const createClient = ({ token, appId }: ConfigYourViews) => {
         count: count ?? productIds.length,
         productIds: productIds.join(","),
       } as unknown as Record<string, string>)}`,
-      { headers },
+      { headers, withProxyCache: true },
     );
 
   /** @description https://yourviews.freshdesk.com/support/solutions/articles/5000740469-buscar-reviews-de-produto */
@@ -61,6 +61,7 @@ export const createClient = ({ token, appId }: ConfigYourViews) => {
       )}`,
       {
         headers,
+        withProxyCache: true,
       },
     );
 
@@ -77,6 +78,7 @@ export const createClient = ({ token, appId }: ConfigYourViews) => {
       )}`,
       {
         headers,
+        withProxyCache: true,
       },
     );
 

--- a/commerce/yourViews/client.ts
+++ b/commerce/yourViews/client.ts
@@ -13,7 +13,7 @@ export interface PaginationOptions {
   count?: number;
 }
 
-const baseUrl = "http://service.yourviews.com.br";
+const baseUrl = "http://proxy.decocache.com/http://service.yourviews.com.br";
 
 export const createClient = ({ token, appId }: ConfigYourViews) => {
   const headers = {

--- a/utils/fetchAPI.ts
+++ b/utils/fetchAPI.ts
@@ -1,14 +1,47 @@
 import { HttpError } from "./HttpError.ts";
 
-export const fetchAPI = async <T>(
+/**
+ * proxy.decocache.com does not vary with the vary header. For this, we must add a stable cache burst
+ * key to avoid sharing caches with the same cookies etc
+ */
+const toProxyCache = async (
   input: string | Request | URL,
   init?: RequestInit,
+) => {
+  const url = typeof input === "string"
+    ? new URL(input)
+    : input instanceof Request
+    ? new URL(input.url)
+    : input;
+
+  const proxyUrl = new URL(`https://proxy.decocache.com/${url.href}`);
+
+  const buffer = await crypto.subtle.digest(
+    "SHA-1",
+    new TextEncoder().encode(
+      JSON.stringify([...new Headers(init?.headers).entries()]),
+    ),
+  );
+
+  const hex = Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+
+  proxyUrl.searchParams.append("_decoProxyCB", hex);
+
+  return proxyUrl;
+};
+
+export const fetchAPI = async <T>(
+  input: string | Request | URL,
+  init?: RequestInit & { withProxyCache?: boolean },
 ): Promise<T> => {
   const headers = new Headers(init?.headers);
 
   headers.set("accept", "application/json");
 
-  const response = await fetch(input, {
+  const url = init?.withProxyCache ? await toProxyCache(input, init) : input;
+  const response = await fetch(url, {
     ...init,
     headers,
   });


### PR DESCRIPTION
This PR uses the new proxy.decocache.com for vtex,vnda & yourviews clients.

This domains introduces the following architecture:

Browser -> CloudFlare -> Fastly -> Deno Deploy -> ...

To use this new proxy, add the https://proxy.decocache.com in front of your usual request, so, to use it to cache https://example.com, just
```
curl https://proxy.decocache.com/https://example.com
```

This should add the necessary stale cache to the request.

Things I'm not really sure are the cdn configuration and certificates used to setup everything