### PR TITLE
Remove empty string of allowed type

### DIFF
--- a/functions/vtexLegacyRelatedProductsLoader.ts
+++ b/functions/vtexLegacyRelatedProductsLoader.ts
@@ -10,7 +10,7 @@ export interface Props {
    * @title Related Products
    * @description VTEX Cross Selling API. This loader only works on routes of type /:slug/p
    */
-  crossSelling?: "" | CrossSellingType;
+  crossSelling?: CrossSellingType;
   /**
    * @description: number of related products
    */


### PR DESCRIPTION
Remove empty string of allowed values for crosselingOptions of VtexLagacyRelatedProducts. 

This allowed value causes a weird comportament that not shows any value of  `CrossSellingType` until you write a valid value of this enum and duplicate the field on CMS

example:

![image](https://user-images.githubusercontent.com/48053804/235671141-33b0f748-22b1-4a24-b5c7-5691b79741a7.png)


fixed version:

![image](https://user-images.githubusercontent.com/48053804/235671286-9856d21b-e938-4073-b339-63d8c3bdd469.png)
