### PR TITLE
feat: add filters behavior on legacy

### DIFF
--- a/import_map.json
+++ b/import_map.json
@@ -1,7 +1,7 @@
 {
   "imports": {
     "deco-sites/std/": "./",
-    "$live/": "https://denopkg.com/deco-cx/live@1.0.17/",
+    "$live/": "https://denopkg.com/deco-cx/live@1.0.18/",
     "partytown/": "https://deno.land/x/partytown@0.2.1/",
     "$fresh/": "https://deno.land/x/fresh@1.1.5/",
     "preact": "https://esm.sh/preact@10.11.0",

--- a/live.gen.ts
+++ b/live.gen.ts
@@ -94,8 +94,8 @@ import * as i1$$$2 from "$live/sections/UseSlot.tsx";
 import * as i1$$$$0 from "$live/matchers/MatchAlways.ts";
 import * as i1$$$$1 from "$live/matchers/MatchDate.ts";
 import * as i1$$$$2 from "$live/matchers/MatchEnvironment.ts";
-import * as i1$$$$3 from "$live/matchers/MatchMulti.ts";
-import * as i1$$$$4 from "$live/matchers/MatchOrigin.ts";
+import * as i1$$$$3 from "$live/matchers/MatchHost.ts";
+import * as i1$$$$4 from "$live/matchers/MatchMulti.ts";
 import * as i1$$$$5 from "$live/matchers/MatchRandom.ts";
 import * as i1$$$$6 from "$live/matchers/MatchSite.ts";
 import * as i1$$$$7 from "$live/matchers/MatchUserAgent.ts";
@@ -211,8 +211,8 @@ const manifest = {
     "$live/matchers/MatchAlways.ts": i1$$$$0,
     "$live/matchers/MatchDate.ts": i1$$$$1,
     "$live/matchers/MatchEnvironment.ts": i1$$$$2,
-    "$live/matchers/MatchMulti.ts": i1$$$$3,
-    "$live/matchers/MatchOrigin.ts": i1$$$$4,
+    "$live/matchers/MatchHost.ts": i1$$$$3,
+    "$live/matchers/MatchMulti.ts": i1$$$$4,
     "$live/matchers/MatchRandom.ts": i1$$$$5,
     "$live/matchers/MatchSite.ts": i1$$$$6,
     "$live/matchers/MatchUserAgent.ts": i1$$$$7,

--- a/packs/vtex/loaders/legacy/productListingPage.ts
+++ b/packs/vtex/loaders/legacy/productListingPage.ts
@@ -49,6 +49,11 @@ export interface Props {
    * @title Sorting
    */
   sort?: LegacySort;
+
+  /**
+   * @todo
+   */
+  filters?: "dynamic" | "static";
 }
 
 export const sortOptions = [
@@ -61,6 +66,13 @@ export const sortOptions = [
   { label: "discount:desc", value: "OrderByBestDiscountDESC" },
   { label: "relevance:desc", value: "OrderByScoreDESC" },
 ];
+
+const getTerm = (path: string, map: string) => {
+  const mapSegments = map.split(",");
+  const pathSegments = path.replace(/^\/.*/, "").split("/");
+
+  return pathSegments.slice(0, mapSegments.length).join("/");
+};
 
 /**
  * @title VTEX product listing page - Portal
@@ -78,6 +90,7 @@ const loader = async (
   const params = toSegmentParams(segment);
   const search = paths(config!).api.catalog_system.pub;
 
+  const filtersBehavior = props.filters || "dynamic";
   const count = props.count ?? 12;
   const maybeMap = props.map || url.searchParams.get("map") || undefined;
   const maybeTerm = props.term || url.pathname || "";
@@ -100,21 +113,24 @@ const loader = async (
   const [map, term] = missingParams
     ? getMapAndTerm(pageTypes)
     : [maybeMap, maybeTerm];
-
+  const fmap = url.searchParams.get("fmap") ?? map;
   const args = { map, _from, _to, O, ft, fq };
 
-  Object.entries(args).forEach(([key, value]) =>
-    value && params.append(key, value)
-  );
+  const pParams = new URLSearchParams(params);
+  Object.entries(args).map(([key, value]) => value && pParams.set(key, value));
+
+  const fParams = new URLSearchParams(pParams);
+  fmap && fParams.set("map", fmap);
 
   const [vtexProducts, vtexFacets] = await Promise.all([
     fetchAPI<LegacyProduct[]>(
-      `${search.products.search.term(term)}?${params}`,
+      `${search.products.search.term(getTerm(term, map))}?${pParams}`,
       { withProxyCache: true },
     ),
-    fetchAPI<LegacyFacets>(`${search.facets.search.term(term)}?${params}`, {
-      withProxyCache: true,
-    }),
+    fetchAPI<LegacyFacets>(
+      `${search.facets.search.term(getTerm(term, fmap))}?${fParams}`,
+      { withProxyCache: true },
+    ),
   ]);
 
   // Transform VTEX product format into schema.org's compatible format
@@ -130,7 +146,9 @@ const loader = async (
     Departments: vtexFacets.Departments,
     Brands: vtexFacets.Brands,
     ...vtexFacets.SpecificationFilters,
-  }).map(([name, facets]) => legacyFacetToFilter(name, facets, url, map))
+  }).map(([name, facets]) =>
+    legacyFacetToFilter(name, facets, url, map, filtersBehavior)
+  )
     .flat()
     .filter((x): x is Filter => Boolean(x));
   const itemListElement = pageTypesToBreadcrumbList(pageTypes, baseUrl);

--- a/packs/vtex/loaders/legacy/productListingPage.ts
+++ b/packs/vtex/loaders/legacy/productListingPage.ts
@@ -51,7 +51,8 @@ export interface Props {
   sort?: LegacySort;
 
   /**
-   * @todo
+   * @title Filter behavior
+   * @description Set to static to not change the facets when the user filters the search. Dynamic will only show the filters containing products after each filter action
    */
   filters?: "dynamic" | "static";
 }

--- a/schemas.gen.json
+++ b/schemas.gen.json
@@ -2588,6 +2588,20 @@
           ],
           "type": "string",
           "title": "Sort"
+        },
+        "filters": {
+          "anyOf": [
+            {
+              "type": "string",
+              "const": "dynamic"
+            },
+            {
+              "type": "string",
+              "const": "static"
+            }
+          ],
+          "type": "string",
+          "title": "Filters"
         }
       },
       "required": [


### PR DESCRIPTION
This PR adds a new option to VTEX legacy plp loader. 

Setting filters to 'static' will add a `?fmap` param to the querystring. This param will fix the facets into the first page the user has seen. This is usefull if you want the facets not to change when navigating across the PLP and applying filters.

Not setting this param will fallback to the old behavior of changing facets. This behavior is nice since it doesn't allow the user to filter for null product lists