### PR TITLE
feat: Work with legacy params on IS

### DIFF
--- a/packs/vtex/loaders/intelligentSearch/productListingPage.ts
+++ b/packs/vtex/loaders/intelligentSearch/productListingPage.ts
@@ -1,5 +1,5 @@
 import {
-  filtersFromSearchParams,
+  filtersFromURL,
   mergeFacets,
   toFilter,
   toProduct,
@@ -142,7 +142,7 @@ const searchArgsOf = (props: Props, url: URL) => {
     sortOptions[0].value;
   const selectedFacets = mergeFacets(
     props.selectedFacets ?? [],
-    filtersFromSearchParams(url.searchParams),
+    filtersFromURL(url),
   );
   const fuzzy = mapLabelledFuzzyToFuzzy(props.fuzzy) ??
     url.searchParams.get("fuzzy") as Fuzzy;

--- a/packs/vtex/utils/transform.ts
+++ b/packs/vtex/utils/transform.ts
@@ -486,10 +486,27 @@ export const filtersToSearchParams = (
   return searchParams;
 };
 
-export const filtersFromSearchParams = (params: URLSearchParams) => {
-  const selectedFacets: SelectedFacet[] = [];
+/**
+ * Transform ?map urls into selected facets. This happens when a store is migrating
+ * to Deco and also migrating from VTEX Legacy to VTEX Intelligent Search.
+ */
+export const legacyFacetsFromURL = (url: URL) => {
+  const mapSegments = url.searchParams.get("map")?.split(",") ?? [];
+  const pathSegments = url.pathname.split("/").slice(1); // Remove first slash
+  const length = Math.min(mapSegments.length, pathSegments.length);
 
-  params.forEach((value, name) => {
+  const selectedFacets: SelectedFacet[] = [];
+  for (let it = 0; it < length; it++) {
+    selectedFacets.push({ key: mapSegments[it], value: pathSegments[it] });
+  }
+
+  return selectedFacets;
+};
+
+export const filtersFromURL = (url: URL) => {
+  const selectedFacets: SelectedFacet[] = legacyFacetsFromURL(url);
+
+  url.searchParams.forEach((value, name) => {
     const [filter, key] = name.split(".");
 
     if (filter === "filter" && typeof key === "string") {


### PR DESCRIPTION
This PR enables URLs `/{collection}?map=productClusterIds` to work on intelligent search