### PR TITLE
auto resolve tailwind to the default tailwind config

### DIFF
--- a/tailwindv3.ts
+++ b/tailwindv3.ts
@@ -17,10 +17,16 @@ const DEFAULT_TAILWIND_CSS = `
 `;
 
 const dev = async (
-  partialConfig: Partial<TailwindConfig> = DEFAULT_OPTIONS,
+  partialConfig?: Partial<TailwindConfig>,
 ) => {
   const start = performance.now();
-  const config = { ...DEFAULT_OPTIONS, ...partialConfig };
+
+  // Try to recover config from default file, a.k.a tailwind.config.ts
+  const config = partialConfig
+    ? { ...DEFAULT_OPTIONS, ...partialConfig }
+    : await import(`${Deno.cwd()}/tailwind.config.ts`)
+      .then((mod) => mod.default)
+      .catch(() => DEFAULT_OPTIONS);
 
   const processor = postcss([
     (tailwindcss as PluginCreator)(config),


### PR DESCRIPTION
This PR allows you to use tailwind without passing a default config. This is good if you use VSCode intellisense. 

Before
```tsx
// in dev.ts
import { tailwind } from 'deco-sites/std/tailwindv3.ts'
import config from 'tailwind.config.ts'

tailwind(config)
```

After
```
// in dev.ts
import { tailwind } from 'deco-sites/std/tailiwndv3.ts'

tailwind()  // No need to pass config. It will be auto resolved to tailwind.config.ts 🎉 
```