### PR TITLE
Related Products loader :: remove throw new error and add unavailable items 

### DIFF
--- a/functions/vtexLegacyRelatedProductsLoader.ts
+++ b/functions/vtexLegacyRelatedProductsLoader.ts
@@ -16,6 +16,10 @@ export interface Props {
    * @description: number of related products
    */
   count?: number;
+  /**
+   * @description remove unavailable items from result
+   */
+  hideUnavailableItems?: boolean;
 }
 
 /**
@@ -30,13 +34,14 @@ const loaderV0: LoaderFunction<
 > = async (
   req,
   ctx,
-  { crossSelling, count },
+  { crossSelling, count, hideUnavailableItems },
 ) => {
   const data = await loader(
     {
       slug: ctx.params.slug,
       crossSelling,
       count,
+      hideUnavailableItems,
     },
     req,
     ctx.state,

--- a/packs/vtex/loaders/legacy/relatedProductsLoader.ts
+++ b/packs/vtex/loaders/legacy/relatedProductsLoader.ts
@@ -85,7 +85,8 @@ async function loader(
   const productId = await getProductGroupID(props);
 
   if (!productId) {
-    throw new Error("Missing props. Please fill: slug or id");
+    // throw new Error("Missing props. Please fill: slug or id");
+    return null;
   }
 
   const vtexRelatedProducts = await fetchAPI<LegacyProduct[]>(


### PR DESCRIPTION
Problem:
When utilizing the loader ''vtexLegacyRelatedProductsLoader.ts'', the program currently returns the error message "Missing props. Please fill: slug or id." if the product ID does not exist.

Proposed Fixes:

- Modify the loader to handle cases where the product ID is null and provide appropriate handling for such scenarios..
- These fixes aim to improve the behavior of the program by addressing the issue of missing product IDs and enhancing the loader's ability to handle unavailable products.