### PR TITLE
feat: add dynamic autocomplete search count param

### DIFF
--- a/packs/vtex/hooks/useAutocomplete.ts
+++ b/packs/vtex/hooks/useAutocomplete.ts
@@ -21,7 +21,7 @@ const setSearch = debounce(async (search: string, count: number) => {
 }, 250);
 
 const state = {
-  setSearch: (query: string, count: number) => {
+  setSearch: (query: string, count = 4) => {
     loading.value = true;
     setSearch(query, count);
   },

--- a/packs/vtex/hooks/useAutocomplete.ts
+++ b/packs/vtex/hooks/useAutocomplete.ts
@@ -10,9 +10,9 @@ const suggestions = Runtime.create(
   "deco-sites/std/loaders/vtex/intelligentSearch/suggestions.ts",
 );
 
-const setSearch = debounce(async (search: string) => {
+const setSearch = debounce(async (search: string, count: number) => {
   try {
-    payload.value = await suggestions({ query: search, count: 4 });
+    payload.value = await suggestions({ query: search, count });
   } catch (error) {
     console.error("Something went wrong while fetching suggestions \n", error);
   } finally {
@@ -21,9 +21,9 @@ const setSearch = debounce(async (search: string) => {
 }, 250);
 
 const state = {
-  setSearch: (s: string) => {
+  setSearch: (query: string, count: number) => {
     loading.value = true;
-    setSearch(s);
+    setSearch(query, count);
   },
   loading,
   suggestions: payload,


### PR DESCRIPTION
This PR removes the fixed **"count"** param used in Autocomplete hook. This amplify the use of dynamic queries on components like a searchbar.

It alsos changes the params to more clear names, for better intellisense.