### PR TITLE
fix: canonical tags

### DIFF
--- a/packs/vtex/utils/legacy.ts
+++ b/packs/vtex/utils/legacy.ts
@@ -110,9 +110,11 @@ export const pageTypesToSeo = (pages: PageType[], req: Request): Seo | null => {
     return null;
   }
 
+  const [_, pathname] = current.url?.split(".vtexcommercestable.com.br") ?? [];
+
   return {
     title: current.title!,
     description: current.metaTagDescription!,
-    canonical: new URL(current.url!, req.url).href,
+    canonical: new URL(pathname, req.url).href,
   };
 };

--- a/schemas.gen.json
+++ b/schemas.gen.json
@@ -7300,6 +7300,14 @@
           ],
           "title": "Canonical URL"
         },
+        "noIndexNoFollow": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "title": "Disable indexing",
+          "description": "In testing, you can use this to prevent search engines from indexing your site"
+        },
         "context": {
           "$ref": "#/definitions/ZGVjby1zaXRlcy9zdGQvY29tbWVyY2UvdHlwZXMudHM=@ProductDetailsPage|null|ProductListingPage|null",
           "title": "Context"


### PR DESCRIPTION
PageType api does not return the url's protocol, breaking JavaScript's URL logic. This PR addresses this issue by using the pathname only