### PR TITLE
fix: HideUnnavailableItems for related products

### DIFF
--- a/import_map.json
+++ b/import_map.json
@@ -1,7 +1,7 @@
 {
   "imports": {
     "deco-sites/std/": "./",
-    "$live/": "https://denopkg.com/deco-cx/live@1.12.4/",
+    "$live/": "https://denopkg.com/deco-cx/live@1.12.11/",
     "partytown/": "https://deno.land/x/partytown@0.3.4/",
     "$fresh/": "https://denopkg.com/deco-cx/fresh@1.2.0/",
     "preact": "https://esm.sh/preact@10.11.0",

--- a/packs/vtex/loaders/legacy/relatedProductsLoader.ts
+++ b/packs/vtex/loaders/legacy/relatedProductsLoader.ts
@@ -1,6 +1,9 @@
 import { fetchAPI } from "deco-sites/std/utils/fetchVTEX.ts";
 import { paths } from "deco-sites/std/packs/vtex/utils/paths.ts";
-import { toProduct } from "deco-sites/std/packs/vtex/utils/transform.ts";
+import {
+  pickSku,
+  toProduct,
+} from "deco-sites/std/packs/vtex/utils/transform.ts";
 import { RequestURLParam } from "deco-sites/std/functions/requestToParam.ts";
 import {
   getSegment,
@@ -35,7 +38,7 @@ export interface Props {
    */
   id?: string;
   /**
-   * @description remove unavailable items from result
+   * @description remove unavailable items from result. This may result in slower websites
    */
   hideUnavailableItems?: boolean;
 }
@@ -104,7 +107,7 @@ async function loader(
 
   const relatedProducts = vtexRelatedProducts
     .slice(0, count ?? Infinity)
-    .map((p) => toProduct(p, p.items[0], 0, options));
+    .map((p) => toProduct(p, pickSku(p), 0, options));
 
   setSegment(segment, ctx.response.headers);
 

--- a/packs/vtex/utils/transform.ts
+++ b/packs/vtex/utils/transform.ts
@@ -70,11 +70,21 @@ interface ProductOptions {
   priceCurrency: string;
 }
 
+/** Returns first available sku */
+const findFirstAvailable = (items: Array<LegacySkuVTEX | SkuVTEX>) =>
+  items?.find((item) =>
+    Boolean(
+      item?.sellers?.find((s) => s.commertialOffer?.AvailableQuantity > 0),
+    )
+  );
+
 export const pickSku = <T extends ProductVTEX | LegacyProductVTEX>(
   product: T,
-  maybeSkuId: string | undefined,
+  maybeSkuId?: string,
 ): T["items"][number] => {
-  const skuId = maybeSkuId ?? product.items[0]?.itemId;
+  const skuId = maybeSkuId ??
+    findFirstAvailable(product.items)?.itemId ??
+    product.items[0]?.itemId;
 
   for (const item of product.items) {
     if (item.itemId === skuId) {

--- a/schemas.gen.json
+++ b/schemas.gen.json
@@ -6606,7 +6606,7 @@
             "boolean",
             "null"
           ],
-          "description": "remove unavailable items from result",
+          "description": "remove unavailable items from result. This may result in slower websites",
           "title": "Hide Unavailable Items"
         }
       },


### PR DESCRIPTION
This PR fixes hideUnnavailableItems for related products. 

The issue was that the `hideUnnavailableItems` feature had to be implemented on the loader side, since VTEX API does not support this feature. This lead to us picking the an unnavailable SKU, which removed the product from the shelf. 
This PR picks an available sku instead of the first one.