### PR TITLE
fix: pageCategory for vtex compatibility layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ We are committed to avoiding breaking changes at all costs. The product is still
 If and when breaking changes occur, they will be signaled with a new Major version on the git tags.
 
 ## VTEX Portal Data Layer Compatibility
+
+> :warning: The compatibility layer requires structured data from the SEO/SEOPLP/SEOPDP component to be present on every page.
+
 How to use:
 1. add the AddVTEXPortalData at routes/_app.tsx after <props.Component />. Example:
 ```tsx
@@ -38,9 +41,7 @@ export default function ProductDetails({ page }: Props) {
       <Breadcrumb
         itemListElement={breadcrumbList?.itemListElement.slice(0, -1)}
       />
-      <Head>
-        <ProductDetailsTemplate product={page.product} />
-      </Head>
+      <ProductDetailsTemplate product={page.product} />
       {/* ... */}
     </>
   );
@@ -48,6 +49,8 @@ export default function ProductDetails({ page }: Props) {
 ```
 3. Add ProductInfo to all rendered products on all pages.
 4. Add VTEXPortalDataLayerCompatibility section to PDP if necessary, to add skuJson.
+
+To disable the scripts to work outside partytown, change the all components type property to something different from `text/partytown`, example: `type="module"`.
 
 # Thanks to all contributors!
 

--- a/components/VTEXPortalDataLayerCompatibility.tsx
+++ b/components/VTEXPortalDataLayerCompatibility.tsx
@@ -133,12 +133,14 @@ export function AddVTEXPortalData(
   );
 }
 
-interface ProductDetailsProps {
+interface ProductDetailsTemplateProps {
   product: Product;
 }
 
 export function ProductDetailsTemplate(
-  { product, ...props }: ProductDetailsProps,
+  { product, ...props }:
+    & ScriptProps
+    & ProductDetailsTemplateProps,
 ) {
   const departament = product.additionalProperty?.find((p) =>
     p.name === "category"
@@ -189,10 +191,11 @@ export function ProductDetailsTemplate(
 
 interface ProductInfoProps {
   product: Product;
-  type?: string;
 }
 
-export function ProductInfo({ product, ...props }: ProductInfoProps) {
+export function ProductInfo(
+  { product, ...props }: ScriptProps & ProductInfoProps,
+) {
   if (!product.isVariantOf?.productGroupID) return null;
   return (
     <Script

--- a/components/VTEXPortalDataLayerCompatibility.tsx
+++ b/components/VTEXPortalDataLayerCompatibility.tsx
@@ -29,7 +29,7 @@ function addVTEXPortalDataSnippet(accountName: string) {
   performance.mark("end-sd");
 
   // deno-lint-ignore no-explicit-any
-  const getPageType = (hasStructuredData: undefined | Record<string, any>) => {
+  const getPageType = (structuredData: undefined | Record<string, any>) => {
     if (url.pathname === "/") return "homeView";
 
     const isProductPage = structuredDatas.some((s) => s["@type"] === "Product");
@@ -38,13 +38,11 @@ function addVTEXPortalDataSnippet(accountName: string) {
     const isSearchPage = url.pathname === "/s";
     if (isSearchPage) return "internalSiteSearchView";
 
-    const pathNames = url.pathname.split("/").filter(Boolean);
-
-    if (pathNames.length === 1 && hasStructuredData) {
+    if (structuredData?.itemList?.length === 1) {
       return "departmentView";
     }
 
-    if (pathNames.length >= 2 && hasStructuredData) {
+    if (structuredData?.itemList?.length >= 2) {
       return "categoryView";
     }
 
@@ -91,6 +89,11 @@ function addVTEXPortalDataSnippet(accountName: string) {
   if (pageType === "internalSiteSearchView") {
     props.pageCategory = "InternalSiteSearch";
     props.siteSearchTerm = url.searchParams.get("q");
+  }
+
+  if (pageType === "otherView") {
+    const pathNames = url.pathname.split("/").filter(Boolean);
+    props.pageCategory = pathNames.pop();
   }
 
   props.shelfProductIds = window.shelfProductIds || [];

--- a/components/VTEXPortalDataLayerCompatibility.tsx
+++ b/components/VTEXPortalDataLayerCompatibility.tsx
@@ -93,7 +93,7 @@ function addVTEXPortalDataSnippet(accountName: string) {
 
   if (pageType === "otherView") {
     const pathNames = url.pathname.split("/").filter(Boolean);
-    props.pageCategory = pathNames.pop();
+    props.pageCategory = pathNames.pop() || null;
   }
 
   props.shelfProductIds = window.shelfProductIds || [];


### PR DESCRIPTION
This PR fixes the page category of vtex compatibility layer, when page is type `otherView`.

Before:
```jsonc
{// dataLayer[0]
    "pageCategory": "Department",
    "pageDepartment": null,
// ....
}
{event: 'otherView'}
```
After:
```jsonc
{ // dataLayer[0]
    "pageCategory": "mtv",
    "pageDepartment": null,
   // ....
}
{event: 'otherView'}
```