### PR TITLE
feat: add favicon on PDP and PLP

### DIFF
--- a/components/seo/SEOPDP.tsx
+++ b/components/seo/SEOPDP.tsx
@@ -1,7 +1,8 @@
-import Metatags from "./Metatags.tsx";
 import type { LoaderReturnType } from "$live/types.ts";
 import { DEFAULT_CATEGORY_SEPARATOR } from "deco-sites/std/commerce/utils.ts";
+import type { Image as LiveImage } from "deco-sites/std/components/types.ts";
 import type { ProductDetailsPage } from "../../commerce/types.ts";
+import Metatags from "./Metatags.tsx";
 
 export interface Props {
   /**
@@ -14,6 +15,8 @@ export interface Props {
   title?: string;
   /** @title Meta tag description override */
   description?: string;
+  /** @description Recommended: 16 x 16 px */
+  favicon?: LiveImage;
   page: LoaderReturnType<ProductDetailsPage | null>;
   structuredData?: {
     useDataFromSEO?: boolean;

--- a/components/seo/SEOPLP.tsx
+++ b/components/seo/SEOPLP.tsx
@@ -1,6 +1,7 @@
-import Metatags from "./Metatags.tsx";
 import type { LoaderReturnType } from "$live/types.ts";
+import type { Image as LiveImage } from "deco-sites/std/components/types.ts";
 import type { ProductListingPage } from "../../commerce/types.ts";
+import Metatags from "./Metatags.tsx";
 
 export interface Props {
   page: LoaderReturnType<ProductListingPage | null>;
@@ -14,6 +15,8 @@ export interface Props {
   title?: string;
   /** @title Metatag description override */
   description?: string;
+  /** @description Recommended: 16 x 16 px */
+  favicon?: LiveImage;
 }
 
 const SeoPLP = (props: Props) => <Metatags {...props} context={props.page} />;

--- a/schemas.gen.json
+++ b/schemas.gen.json
@@ -1748,7 +1748,7 @@
           }
         },
         {
-          "title": "deco-sites/std/loaders/nuvemShop/nuvemShopProductDetailsPage.ts",
+          "title": "NuvemShop - PDP",
           "type": "object",
           "allOf": [
             {
@@ -7884,6 +7884,11 @@
           ],
           "title": "Meta tag description override"
         },
+        "favicon": {
+          "$ref": "#/definitions/ZGVjby1zaXRlcy9zdGQvY29tcG9uZW50cy90eXBlcy50cw==@Image",
+          "description": "Recommended: 16 x 16 px",
+          "title": "Favicon"
+        },
         "page": {
           "$ref": "#/definitions/ZGVjby1zaXRlcy9zdGQvY29tbWVyY2UvdHlwZXMudHM=@ProductDetailsPage|null",
           "title": "Page"
@@ -7937,6 +7942,11 @@
             "null"
           ],
           "title": "Metatag description override"
+        },
+        "favicon": {
+          "$ref": "#/definitions/ZGVjby1zaXRlcy9zdGQvY29tcG9uZW50cy90eXBlcy50cw==@Image",
+          "description": "Recommended: 16 x 16 px",
+          "title": "Favicon"
         }
       },
       "required": [
@@ -9571,7 +9581,7 @@
       }
     },
     "ZGVjby1zaXRlcy9zdGQvbG9hZGVycy9udXZlbVNob3AvbnV2ZW1TaG9wUHJvZHVjdERldGFpbHNQYWdlLnRz": {
-      "title": "deco-sites/std/loaders/nuvemShop/nuvemShopProductDetailsPage.ts",
+      "title": "NuvemShop - PDP",
       "type": "object",
       "allOf": [
         {


### PR DESCRIPTION
Nowadays the PDP and PLP do not have Favicon using the SEOPLP and SEOPDP.

https://boilerplaten1.deco.site/departamento-1

https://boilerplaten1.deco.site/bone-aberto-new-era/p?skuId=231

https://deco.cx/admin/sites/boilerplaten1/blocks/Categories?revisionId=23950d61-8080-4e5d-bcab-2fc7ea5676e5&returnUrl=%2Fadmin%2Fsites%2Fboilerplaten1%2Fpages&returnLabel=Pages&path=%252F&pathTemplate=%252F*&tab=0

https://deco.cx/admin/sites/boilerplaten1/blocks/Product%20Page?revisionId=5d2aae50-165e-42a4-b059-57d6047e8435&returnUrl=%2Fadmin%2Fsites%2Fboilerplaten1%2Fpages&returnLabel=Pages&path=%252F%253Aslug%252Fp&pathTemplate=%252F%253Aslug%252Fp&tab=0