### PR TITLE
fix: seo preview

### DIFF
--- a/components/seo/components/Preview.tsx
+++ b/components/seo/components/Preview.tsx
@@ -57,10 +57,14 @@ function PreviewHandler(props: Props) {
   return (
     <>
       <Head>
-        <script src="https://cdn.tailwindcss.com" />
+        <script id="cdn.tailwindcss.com" src="https://cdn.tailwindcss.com" />
         <script
           dangerouslySetInnerHTML={{
-            __html: `tailwind.config = ${JSON.stringify(tailwind)}`,
+            __html:
+              `document.getElementById("cdn.tailwindcss.com").addEventListener('load', () => { tailwind.config = ${
+                JSON.stringify(tailwind)
+              }})
+            `,
           }}
         />
       </Head>


### PR DESCRIPTION
This PR addresses this issue
<img width="771" alt="image" src="https://github.com/deco-sites/std/assets/1753396/1a04fea7-aa36-44a7-b734-cd9ccdbb131e">

This is because we are kind of re-implemeting script execution after we are keeping the iframe for navigating