### PR TITLE
hotfix: encode url

### DIFF
--- a/packs/vtex/loaders/legacy/productList.ts
+++ b/packs/vtex/loaders/legacy/productList.ts
@@ -109,7 +109,7 @@ const fromProps = (
     return params;
   }
 
-  props.term && params.set("ft", props.term);
+  props.term && params.set("ft", encodeURIComponent(props.term));
 
   return params;
 };


### PR DESCRIPTION
This API still plays me after so long time.

<img width="433" alt="image" src="https://github.com/deco-sites/std/assets/1753396/ce6e5cab-854c-4580-b20d-ddb9dfa8bed3">
