### PR TITLE
Allow Category tree on vtex legacy Filters and fixes url with the same page on Department Filters

### DIFF
--- a/packs/vtex/types.ts
+++ b/packs/vtex/types.ts
@@ -661,6 +661,7 @@ export type LegacyProduct = IProduct & {
 
 export type LegacyFacets = {
   Departments: LegacyFacet[];
+  CategoriesTrees: LegacyFacet[];
   Brands: LegacyFacet[];
   SpecificationFilters: Record<string, LegacyFacet[]>;
 };

--- a/packs/vtex/utils/transform.ts
+++ b/packs/vtex/utils/transform.ts
@@ -448,9 +448,9 @@ export const legacyFacetToFilter = (
 
   const getLink = (facet: LegacyFacet, selected: boolean) => {
     // Do not allow removing root facet to avoid going back to home page
-    if (mapSegments.length === 1) {
-      return `${url.pathname}${url.search}`;
-    }
+    // if (mapSegments.length === 1) {
+    //   return `${url.pathname}${url.search}`;
+    // }
 
     const index = pathSegments.findIndex((s) => s === facet.Value);
     const newMap = selected


### PR DESCRIPTION
### Feature description:

This PR Allows the category tree filters to Vtex Legacy ProductListingPage. By sending to front the categories below the current department or category. 

![image](https://github.com/deco-sites/std/assets/49959786/89dd1f1b-9478-44d9-8e90-3758657c4ac8)

### Use case:
https://www.austral.com.br/masculino?O=OrderByScoreDESC
https://australroupas.deco.site/masculino?O=OrderByScoreDESC

### Fix description:

In the Department page like /masculino at austral, all filters come with the same current url. With this fix, this no longer happens.

### Use case:
https://australroupas.deco.site/masculino?O=OrderByScoreDESC