### PR TITLE
feat: add Brand to Product

### DIFF
--- a/commerce/nuvemShop/transform.ts
+++ b/commerce/nuvemShop/transform.ts
@@ -73,7 +73,7 @@ function productVariantToProduct(
       url: image.src,
     })),
     category: getPreferredLanguage(categories[0]?.name || ""), // Assuming there's only one category
-    brand: brand,
+    brand: { "@type": "Brand", name: brand },
     offers: {
       "@type": "AggregateOffer" as const,
       priceCurrency: "BRL",

--- a/commerce/shopify/transform.ts
+++ b/commerce/shopify/transform.ts
@@ -125,7 +125,7 @@ export const toProduct = (
     description,
     sku: productID,
     gtin: barcode,
-    brand: vendor,
+    brand: { "@type": "Brand", name: vendor },
     releaseDate: createdAt,
     additionalProperty,
     isVariantOf: {

--- a/commerce/types.ts
+++ b/commerce/types.ts
@@ -239,6 +239,12 @@ export interface ProductGroup extends Omit<Thing, "@type"> {
   model?: string;
 }
 
+export interface Brand extends Omit<Thing, "@type"> {
+  "@type": "Brand";
+  /** Brand's image url */
+  logo?: string;
+}
+
 export interface Product extends Omit<Thing, "@type"> {
   "@type": "Product";
   /**
@@ -252,7 +258,7 @@ export interface Product extends Omit<Thing, "@type"> {
   /** An award won by or for this item. */
   award?: string;
   /** The brand(s) associated with a product or service, or the brand(s) maintained by an organization or business person. */
-  brand?: string;
+  brand?: string | Brand;
   /** A category for the item. Greater signs or slashes can be used to informally indicate a category hierarchy. */
   category?: string;
   /** A Global Trade Item Number ({@link https://www.gs1.org/standards/id-keys/gtin GTIN}). GTINs identify trade items, including products and services, using numeric identification codes. The {@link https://schema.org/gtin gtin} property generalizes the earlier {@link https://schema.org/gtin8 gtin8}, {@link https://schema.org/gtin12 gtin12}, {@link https://schema.org/gtin13 gtin13}, and {@link https://schema.org/gtin14 gtin14} properties. The GS1 {@link https://www.gs1.org/standards/Digital-Link/ digital link specifications} express GTINs as URLs. A correct {@link https://schema.org/gtin gtin} value should be a valid GTIN, which means that it should be an all-numeric string of either 8, 12, 13 or 14 digits, or a "GS1 Digital Link" URL based on such a string. The numeric component should also have a {@link https://www.gs1.org/services/check-digit-calculator valid GS1 check digit} and meet the other rules for valid GTINs. See also {@link http://www.gs1.org/barcodes/technical/idkeys/gtin GS1's GTIN Summary} and {@link https://en.wikipedia.org/wiki/Global_Trade_Item_Number Wikipedia} for more details. Left-padding of the gtin values is not required or encouraged. */

--- a/commerce/types.ts
+++ b/commerce/types.ts
@@ -258,7 +258,7 @@ export interface Product extends Omit<Thing, "@type"> {
   /** An award won by or for this item. */
   award?: string;
   /** The brand(s) associated with a product or service, or the brand(s) maintained by an organization or business person. */
-  brand?: string | Brand;
+  brand?: Brand;
   /** A category for the item. Greater signs or slashes can be used to informally indicate a category hierarchy. */
   category?: string;
   /** A Global Trade Item Number ({@link https://www.gs1.org/standards/id-keys/gtin GTIN}). GTINs identify trade items, including products and services, using numeric identification codes. The {@link https://schema.org/gtin gtin} property generalizes the earlier {@link https://schema.org/gtin8 gtin8}, {@link https://schema.org/gtin12 gtin12}, {@link https://schema.org/gtin13 gtin13}, and {@link https://schema.org/gtin14 gtin14} properties. The GS1 {@link https://www.gs1.org/standards/Digital-Link/ digital link specifications} express GTINs as URLs. A correct {@link https://schema.org/gtin gtin} value should be a valid GTIN, which means that it should be an all-numeric string of either 8, 12, 13 or 14 digits, or a "GS1 Digital Link" URL based on such a string. The numeric component should also have a {@link https://www.gs1.org/services/check-digit-calculator valid GS1 check digit} and meet the other rules for valid GTINs. See also {@link http://www.gs1.org/barcodes/technical/idkeys/gtin GS1's GTIN Summary} and {@link https://en.wikipedia.org/wiki/Global_Trade_Item_Number Wikipedia} for more details. Left-padding of the gtin values is not required or encouraged. */

--- a/packs/linxImpulse/utils/transform.ts
+++ b/packs/linxImpulse/utils/transform.ts
@@ -161,7 +161,10 @@ export const toProduct = <P extends ProductLinxImpulse>(
     url: getProductURL(baseUrl, product, skuId).href,
     name,
     description: description ?? "",
-    brand: details?.brand as string ?? "",
+    brand: {
+      "@type": "Brand",
+      name: typeof details?.brand === "string" ? details.brand : "",
+    },
     sku: skuId,
     gtin: eanCode,
     releaseDate: "",

--- a/packs/vtex/types.ts
+++ b/packs/vtex/types.ts
@@ -627,6 +627,7 @@ export interface IProduct {
   productName: string;
   brand: string;
   brandId: number;
+  brandImageUrl?: string;
   cacheId?: string;
   linkText: string;
   productReference: string;

--- a/packs/vtex/utils/transform.ts
+++ b/packs/vtex/utils/transform.ts
@@ -218,6 +218,8 @@ export const toProduct = <P extends LegacyProductVTEX | ProductVTEX>(
   const { baseUrl, priceCurrency } = options;
   const {
     brand,
+    brandId,
+    brandImageUrl,
     productId,
     productReference,
     description,
@@ -268,7 +270,12 @@ export const toProduct = <P extends LegacyProductVTEX | ProductVTEX>(
     url: getProductURL(baseUrl, product, sku.itemId).href,
     name,
     description,
-    brand,
+    brand: {
+      "@type": "Brand",
+      "@id": brandId?.toString(),
+      name: brand,
+      logo: brandImageUrl,
+    },
     sku: skuId,
     gtin: ean,
     releaseDate,


### PR DESCRIPTION
This PR changes the brand type on the Product interface so we can use schema.org Brand interface: 
https://schema.org/Brand

This PR is a BREAKING CHANGE because it now returns a Brand object instead of a string. I, however, think that this is ok because I don't remember anyone using this field anywhere. I tested on fashion and it's ok so far
