### PR TITLE
feat: added teasers to catalog loader

### DIFF
--- a/packs/vtex/types.ts
+++ b/packs/vtex/types.ts
@@ -756,6 +756,27 @@ export interface Item {
   }>;
 }
 
+export interface TeasersParameters {
+  "<Name>k__BackingField": string;
+  "<Value>k__BackingField": string;
+}
+
+export interface TeasersConditions {
+  "<MinimumQuantity>k__BackingField": number;
+  "<Parameters>k__BackingField": TeasersParameters[];
+}
+
+export interface TeasersEffect {
+  "<Parameters>k__BackingField": TeasersParameters[];
+}
+
+export interface Teasers {
+  "<Name>k__BackingField": string;
+  "<GeneralValues>k__BackingField": unknown;
+  "<Conditions>k__BackingField": TeasersConditions;
+  "<Effects>k__BackingField": TeasersEffect;
+}
+
 export interface CommertialOffer {
   DeliverySlaSamplesPerRegion: Record<
     string,
@@ -764,7 +785,7 @@ export interface CommertialOffer {
   Installments: Installment[];
   DiscountHighLight: unknown[];
   GiftSkuIds: string[];
-  Teasers: Array<Record<string, unknown>>;
+  Teasers: Teasers[];
   teasers?: Array<Record<string, unknown>>;
   BuyTogether: unknown[];
   ItemMetadataAttachment: unknown[];

--- a/packs/vtex/utils/transform.ts
+++ b/packs/vtex/utils/transform.ts
@@ -443,7 +443,7 @@ const toOfferLegacy = (
     name: teaser["<Name>k__BackingField"],
     generalValues: teaser["<GeneralValues>k__BackingField"],
     conditions: {
-      name: teaser["<Conditions>k__BackingField"][
+      minimumQuantity: teaser["<Conditions>k__BackingField"][
         "<MinimumQuantity>k__BackingField"
       ],
       parameters:


### PR DESCRIPTION
Good morning friends,

Added to this pull request, the return of teasers for legacy loaders,
previously only intelligent-search loaders had the data filled in.

Teasers were also typed for data transformation.

Best regards.
Jonathan Lopes (Mineiro).