### PR TITLE
feat: use cover by default

### DIFF
--- a/packs/image/components/Image.tsx
+++ b/packs/image/components/Image.tsx
@@ -30,7 +30,7 @@ export const getOptimizedMediaUrl = (
   const params = new URLSearchParams();
 
   params.set("src", originalSrc);
-  params.set("fit", "contain");
+  params.set("fit", "cover");
   params.set("width", `${Math.trunc(factor * width)}`);
   height && params.set("height", `${Math.trunc(factor * height)}`);
 


### PR DESCRIPTION
Use cover by default so developers dont need to use object-cover and have total control over dimensions