### PR TITLE
fix: teasers types front

### DIFF
--- a/commerce/types.ts
+++ b/commerce/types.ts
@@ -142,6 +142,27 @@ export interface UnitPriceSpecification
   billingIncrement?: number;
 }
 
+export interface TeasersParameters {
+  name: string;
+  value: string;
+}
+
+export interface TeasersConditions {
+  minimumQuantity: number;
+  parameters: TeasersParameters[];
+}
+
+export interface TeasersEffect {
+  parameters: TeasersParameters[];
+}
+
+export interface Teasers {
+  name: string;
+  generalValues?: unknown;
+  conditions: TeasersConditions;
+  effects: TeasersEffect;
+}
+
 export interface Offer extends Omit<Thing, "@type"> {
   "@type": "Offer";
   /** The availability of this item—for example In stock, Out of stock, Pre-order, etc. */
@@ -171,7 +192,7 @@ export interface Offer extends Omit<Thing, "@type"> {
   /** The Stock Keeping Unit (SKU), i.e. a merchant-specific identifier for a product or service, or the product to which the offer refers. */
   sku?: string;
   /** Used by some ecommerce providers (e.g: VTEX) to describe special promotions that depend on some conditions */
-  teasers?: Array<Record<string, unknown>>;
+  teasers?: Teasers[];
 }
 
 export interface AggregateOffer {

--- a/packs/vtex/types.ts
+++ b/packs/vtex/types.ts
@@ -757,25 +757,46 @@ export interface Item {
   }>;
 }
 
-export interface TeasersParameters {
+export interface TeasersParametersLegacy {
   "<Name>k__BackingField": string;
   "<Value>k__BackingField": string;
 }
 
-export interface TeasersConditions {
+export interface TeasersConditionsLegacy {
   "<MinimumQuantity>k__BackingField": number;
-  "<Parameters>k__BackingField": TeasersParameters[];
+  "<Parameters>k__BackingField": TeasersParametersLegacy[];
+}
+
+export interface TeasersEffectLegacy {
+  "<Parameters>k__BackingField": TeasersParametersLegacy[];
+}
+
+export interface TeasersLegacy {
+  "<Name>k__BackingField": string;
+  "<GeneralValues>k__BackingField": unknown;
+  "<Conditions>k__BackingField": TeasersConditionsLegacy;
+  "<Effects>k__BackingField": TeasersEffectLegacy;
+}
+
+export interface TeasersParameters {
+  name: string;
+  value: string;
+}
+
+export interface TeasersConditions {
+  minimumQuantity: number;
+  parameters: TeasersParameters[];
 }
 
 export interface TeasersEffect {
-  "<Parameters>k__BackingField": TeasersParameters[];
+  parameters: TeasersParameters[];
 }
 
 export interface Teasers {
-  "<Name>k__BackingField": string;
-  "<GeneralValues>k__BackingField": unknown;
-  "<Conditions>k__BackingField": TeasersConditions;
-  "<Effects>k__BackingField": TeasersEffect;
+  name: string;
+  generalValues?: unknown;
+  conditions: TeasersConditions;
+  effects: TeasersEffect;
 }
 
 export interface CommertialOffer {
@@ -786,8 +807,8 @@ export interface CommertialOffer {
   Installments: Installment[];
   DiscountHighLight: unknown[];
   GiftSkuIds: string[];
-  Teasers: Teasers[];
-  teasers?: Array<Record<string, unknown>>;
+  Teasers: TeasersLegacy[];
+  teasers?: Teasers[];
   BuyTogether: unknown[];
   ItemMetadataAttachment: unknown[];
   Price: number;

--- a/packs/vtex/utils/transform.ts
+++ b/packs/vtex/utils/transform.ts
@@ -414,7 +414,7 @@ const toOffer = ({
   seller: sellerId,
   priceValidUntil: offer.PriceValidUntil,
   inventoryLevel: { value: offer.AvailableQuantity },
-  teasers: offer.teasers,
+  teasers: offer.teasers ?? [],
   priceSpecification: [
     {
       "@type": "UnitPriceSpecification",


### PR DESCRIPTION
Good morning,

In this pull request, 
i added teasers typing to reflect in front end.

We receive in the backend Teaser and teasers where Teasers with capital letter come from the Legacy API
Data processing is being done for each of the situations

However, the final types must be the same and this was solved in this pullrequest.