### PR TITLE
Price Range filter on Vtex legacy PLP 

### DIFF
--- a/packs/vtex/loaders/legacy/productListingPage.ts
+++ b/packs/vtex/loaders/legacy/productListingPage.ts
@@ -19,6 +19,7 @@ import {
 } from "deco-sites/std/packs/vtex/utils/segment.ts";
 import {
   legacyFacetToFilter,
+  normalizeFq,
   toProduct,
 } from "deco-sites/std/packs/vtex/utils/transform.ts";
 import { fetchAPI, fetchSafe } from "deco-sites/std/utils/fetchVTEX.ts";
@@ -132,6 +133,8 @@ const loader = async (
   const ft = props.ft || url.searchParams.get("ft") ||
     url.searchParams.get("q") || "";
   const fq = props.fq || url.searchParams.get("fq") || "";
+  const normalizedFq = normalizeFq(fq);
+  const hasPreSelectedFq = props.fq;
   const _from = `${page * count}`;
   const _to = `${(page + 1) * count - 1}`;
 
@@ -146,7 +149,7 @@ const loader = async (
     ? getMapAndTerm(pageTypes)
     : [maybeMap, maybeTerm];
   const fmap = url.searchParams.get("fmap") ?? map;
-  const args = { map, _from, _to, O, ft, fq };
+  const args = { map, _from, _to, O, ft, fq: normalizedFq };
 
   const pParams = new URLSearchParams(params);
   Object.entries(args).map(([key, value]) => value && pParams.set(key, value));
@@ -185,9 +188,10 @@ const loader = async (
   const filters = Object.entries({
     Departments: vtexFacets.Departments,
     Brands: vtexFacets.Brands,
+    PriceRanges: !hasPreSelectedFq ? vtexFacets.PriceRanges : [],
     ...vtexFacets.SpecificationFilters,
   }).map(([name, facets]) =>
-    legacyFacetToFilter(name, facets, url, map, filtersBehavior)
+    legacyFacetToFilter(name, facets, url, map, fq, filtersBehavior)
   )
     .flat()
     .filter((x): x is Filter => Boolean(x));

--- a/packs/vtex/types.ts
+++ b/packs/vtex/types.ts
@@ -663,6 +663,7 @@ export type LegacyProduct = IProduct & {
 export type LegacyFacets = {
   Departments: LegacyFacet[];
   Brands: LegacyFacet[];
+  PriceRanges: LegacyFacet[];
   SpecificationFilters: Record<string, LegacyFacet[]>;
 };
 
@@ -702,6 +703,7 @@ export interface LegacyFacet {
   LinkEncoded: string;
   Map: string;
   Value: string;
+  Slug: string;
   Children: LegacyFacet[];
 }
 


### PR DESCRIPTION
### Feature description

Allows Price Range filter on Vtex legacy ProductListingPage:
![image](https://github.com/deco-sites/std/assets/49959786/b3d4266e-525f-4295-b728-78c570b491de)

By default Vtex sends a JSON like this to loader:
![image](https://github.com/deco-sites/std/assets/49959786/f0031067-3ce7-4505-b89a-1ca41d42ffb8)
But we can't use this url format in deco, because it returns an error, as it can't handle filters of this type.

In this PR we use the `fq=P:[{a} TO {b}]` to filter by the range prices registered in the vtex.