### PR TITLE
fix: add default value to toAdditionalPropertyReferenceId parameter

### DIFF
--- a/packs/vtex/utils/transform.ts
+++ b/packs/vtex/utils/transform.ts
@@ -210,7 +210,7 @@ const toAdditionalPropertyClusters = <
 };
 
 const toAdditionalPropertyReferenceId = (
-  referenceId: Array<{ Key: string; Value: string }>,
+  referenceId: Array<{ Key: string; Value: string }> = [],
 ): Product["additionalProperty"] => {
   return referenceId.map(({ Key, Value }) => ({
     "@type": "PropertyValue" as const,
@@ -245,6 +245,7 @@ export const toProduct = <P extends LegacyProductVTEX | ProductVTEX>(
   const specificationsAdditionalProperty = isLegacySku(sku)
     ? toAdditionalPropertiesLegacy(sku)
     : toAdditionalProperties(sku);
+  console.log(referenceId);
   const referenceIdAdditionalProperty = toAdditionalPropertyReferenceId(
     referenceId,
   );


### PR DESCRIPTION
Some products of the legacy loader vtex may apparently return an undefined reference id, which causes a rendering error. This PR adds a default value `[]` to prevent the function from breaking.

![image](https://github.com/deco-sites/std/assets/48053804/ce9d724a-b3bf-4632-95b5-98e853f84fb8)
