### PR TITLE
Fix VTEX Segment: not replace utm by empty querystrings

### DIFF
--- a/packs/vtex/utils/segment.ts
+++ b/packs/vtex/utils/segment.ts
@@ -48,9 +48,12 @@ export const getSegment = (req: Request): Partial<Segment> => {
 
   return {
     ...partial,
-    utmi_campaign: url.searchParams.get("utmi_campaign") ?? null,
-    utm_campaign: url.searchParams.get("utm_campaign") ?? null,
-    utm_source: url.searchParams.get("utm_source") ?? null,
+    utmi_campaign: url.searchParams.get("utmi_campaign") ??
+      partial.utmi_campaign ?? null,
+    utm_campaign: url.searchParams.get("utm_campaign") ??
+      partial.utm_campaign ?? null,
+    utm_source: url.searchParams.get("utm_source") ?? partial.utm_source ??
+      null,
   };
 };
 


### PR DESCRIPTION
### Bug Description

When the user access some page with a UTM querystring related a promotion and they changes the page, the Segment cookie has replaced to a empty one since it do not have any querystrings on the new page.

1. Enter https://www.bite.com.br/?utm_source=futebol-bite
2. Check a product price
3. Enter on that page
4. See the bug 🐞 

Bug and Resolution video: https://www.loom.com/share/4bd0d74029c54201906c06566f251d7b?sid=efca67e7-44f2-4f2c-b3f4-9aa0682ded7e