### PR TITLE
fix: remove findLast method because of safari

### DIFF
--- a/components/VTEXPortalDataLayerCompatibility.tsx
+++ b/components/VTEXPortalDataLayerCompatibility.tsx
@@ -145,7 +145,7 @@ export function ProductDetailsTemplate(
   const departament = product.additionalProperty?.find((p) =>
     p.name === "category"
   );
-  const category = product.additionalProperty?.findLast((p) =>
+  const category = product.additionalProperty?.slice().reverse().find((p) =>
     p.name === "category"
   );
 


### PR DESCRIPTION
VTEXPortalDataLayerCompatibility was breaking on Safari due to this method. Used a old school way to resolve this.

Screenshot do problema no Safari
![image](https://github.com/deco-sites/std/assets/93907598/fcbe3724-b51b-4d31-9d59-3b022662a6b0)
