### PR TITLE
Normalize utm campaign value to avoid accents.

### DIFF
--- a/utils/fetchVTEX.ts
+++ b/utils/fetchVTEX.ts
@@ -29,9 +29,14 @@ const processFetch = async (
     if (url.searchParams.has(qsToSanatize)) {
       const searchParams = url.searchParams;
       const testParamValues = searchParams.getAll(qsToSanatize);
-      const updatedTestParamValues = testParamValues.map((paramValue) =>
-        paramValue.replace(/\+/g, "").replaceAll(" ", "")
-      );
+      const updatedTestParamValues = testParamValues.map((paramValue) => {
+        const removedPlus = paramValue.replace(/\+/g, "").replaceAll(" ", "");
+        const normalized = removedPlus.normalize("NFD").replace(
+          /[\u0300-\u036f]/g,
+          "",
+        );
+        return normalized;
+      });
       searchParams.delete(qsToSanatize);
       updatedTestParamValues.forEach((updatedValue) =>
         searchParams.append(qsToSanatize, updatedValue)
@@ -39,6 +44,7 @@ const processFetch = async (
     }
   });
 
+  console.log(url.toString());
   return await _fetch(url.toString(), init);
 };
 


### PR DESCRIPTION
Accents break VTEX API on utm_campaigns.

example: `&utm_campaign=Conversão`