### PR TITLE
Proposal :: Meta Tags :: Only render a tag when content is available

### DIFF
--- a/components/seo/Metatags.tsx
+++ b/components/seo/Metatags.tsx
@@ -9,8 +9,14 @@ import Preview from "./components/Preview.tsx";
 import type { Props } from "./types.ts";
 
 function Metatags(props: Props) {
-  const { titleTemplate = "", context, type, themeColor, favicon } = props;
-  const twitterCard = type === "website" ? "summary" : "summary_large_image";
+  const {
+    titleTemplate = "",
+    context,
+    type,
+    themeColor,
+    favicon,
+    twitterCard,
+  } = props;
 
   const tags = context?.["@type"] === "ProductDetailsPage"
     ? tagsFromProduct(context, titleTemplate)
@@ -23,24 +29,40 @@ function Metatags(props: Props) {
   return (
     <>
       <Head>
-        <title>{title}</title>
-        <meta name="description" content={description} />
-        <meta name="theme-color" content={themeColor} />
-        <link rel="icon" href={favicon} />
+        {title && (
+          <>
+            <title>{title}</title>
+            <meta property="og:title" content={title} />
+          </>
+        )}
 
-        {/* Twitter tags */}
-        <meta property="twitter:title" content={title} />
-        <meta property="twitter:description" content={description} />
-        <meta property="twitter:image" content={image} />
-        <meta property="twitter:card" content={twitterCard} />
-        {/* OpenGraph tags */}
-        <meta property="og:title" content={title} />
-        <meta property="og:description" content={description} />
-        <meta property="og:type" content={type} />
-        <meta property="og:image" content={image} />
+        {description && (
+          <>
+            <meta name="description" content={description} />
+            <meta property="og:description" content={description} />
+          </>
+        )}
 
-        {/* Link tags */}
-        {canonical && <link rel="canonical" href={canonical} />}
+        {image && (
+          <>
+            <meta property="og:image" content={image} />
+          </>
+        )}
+
+        {themeColor && <meta name="theme-color" content={themeColor} />}
+
+        {favicon && <link rel="icon" href={favicon} />}
+
+        {twitterCard && <meta property="twitter:card" content={twitterCard} />}
+
+        {type && <meta property="og:type" content={type} />}
+
+        {canonical && (
+          <>
+            <meta property="og:url" content={canonical} />
+            <link rel="canonical" href={canonical} />
+          </>
+        )}
 
         {/* No index, no follow */}
         {props?.noIndexNoFollow && (

--- a/components/seo/types.ts
+++ b/components/seo/types.ts
@@ -12,6 +12,8 @@ export interface Dimensions {
   height: number;
 }
 
+type TwitterCard = "summary" | "summary_large_image";
+
 export interface Props {
   title?: string;
   /**
@@ -31,6 +33,8 @@ export interface Props {
   themeColor?: string;
   /** @title Canonical URL */
   canonical?: string;
+  /** @title Twitter Card */
+  twitterCard?: TwitterCard;
   /**
    * @title Disable indexing
    * @description In testing, you can use this to prevent search engines from indexing your site


### PR DESCRIPTION
## Description

I'd like to propose an use case in which someone adds the base SEO component but doesn't provide any content to render the tags.

This scenario might be interesting for those who wish to leverage the default JSON LD functionality but have a need to provide the remaining tags in any other way.

For this, I'm suggesting that the component skip every tag without content.

## Reasoning / Justification

[Empty tags are the same as no tags](https://webmasters.stackexchange.com/questions/53241/seo-meta-tags-is-it-better-to-have-empty-meta-content-or-no-tag-at-all). Because of that, its better to skip rendering a tag that has no content in it, even for those whose content might be inferred from context.

Also, several SO and device specific tags are not contemplated in the base component, a behavior I agree with. Those tags are usually defined using a custom call to Head since there are several icon sizes and tags for social networks that might not be interesting for every project.

Finally, by avoiding the need to duplicate a tag, the final HTML doc size will be reduced.

## Code explanation

Overall, I've just added a check before rendering any tag. The tags are now unordered, [but the order of elements in the head tag is (usually) not meaningful](https://github.com/bigskysoftware/idiomorph#the-head-tag).

I've also removed most of the Twitter tags since [they have fallbacks relying on OpenGraph tags](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup). I've also added the `og:url` canonical tag. As a final change I've added a select for Twitter Card, but it might be best to just have a separate component specifically for Twitter or any other social network/service.

Since this is mostly a proposal, theres still the need to go over the logic on displaying the previews.

## Wrapping up

I've used this [favicon generator](https://www.favicon-generator.org/) to implement the custom tags on Zee.Dog, and it comes packed with all the files and tags needed. Creating a custom SEO component was then much easier, but still, I wanted to have access to the default JSON LD. Allowing the base SEO component to render only the existing content enabled me to create custom SEO components while still leveraging the LD implementation without the need to duplicate tags.