### PR TITLE
perf: adding defer to Analytics

### DIFF
--- a/components/Analytics.tsx
+++ b/components/Analytics.tsx
@@ -67,6 +67,7 @@ export default function Analtyics(
       <script
         type="module"
         id="analytics-script"
+        defer
         dangerouslySetInnerHTML={{
           __html:
             `window.DECO_SITES_STD = { sendAnalyticsEvent: ${sendAnalyticsEvent.toString()} }`,


### PR DESCRIPTION
## PR Description

This Pull Request aims to make the analytics script asynchronous and add the `defer` attribute to the corresponding `<script>` element in the `Analytics` component. These changes are intended to improve website performance by ensuring that the analytics script is loaded asynchronously, preventing rendering delays.

**Motivation**

The motivation behind these changes is to ensure that the analytics script is loaded asynchronously, allowing the page to continue rendering without significant delays caused by script loading. Additionally, making this script deferred can enhance the user experience, especially on pages with numerous scripts and resources.

**Tests Conducted**

Local tests have been conducted to verify that the analytics script is loaded asynchronously and that other scripts on the page are not affected by the `defer` attribute.

**Impact on PageSpeed**

We have encountered a significant drop in PageSpeed on the Abracadabra website with the insertion of GTM (Google Tag Manager). Therefore, the primary goal of these changes is to mitigate this impact and reduce Total Blocking Time (TBT) to enhance the overall site performance.