### PR TITLE
feat: Integrates TailwindCSS with Decofile

### DIFF
--- a/plugins/tailwind/bundler.ts
+++ b/plugins/tailwind/bundler.ts
@@ -17,7 +17,9 @@ const DEFAULT_TAILWIND_CSS = `
 @tailwind utilities;
 `;
 
-export const bundle = async ({ to, from }: { to: string; from: string }) => {
+export const bundle = async (
+  { to, from, release }: { to: string; from: string; release: string },
+) => {
   const start = performance.now();
 
   // Try to recover config from default file, a.k.a tailwind.config.ts
@@ -26,6 +28,15 @@ export const bundle = async ({ to, from }: { to: string; from: string }) => {
   )
     .then((mod) => mod.default)
     .catch(() => DEFAULT_OPTIONS);
+
+  if (Array.isArray(config.content)) {
+    config.content.push({
+      raw: release,
+      extension: "json",
+    });
+  } else {
+    console.warn("TailwindCSS generation from decofile disabled");
+  }
 
   const processor = postcss([
     // deno-lint-ignore no-explicit-any

--- a/plugins/tailwind/bundler.ts
+++ b/plugins/tailwind/bundler.ts
@@ -1,7 +1,7 @@
 import autoprefixer from "npm:autoprefixer@10.4.14";
 import cssnano from "npm:cssnano@6.0.1";
 import postcss from "npm:postcss@8.4.27";
-import tailwindcss from "npm:tailwindcss@3.3.3";
+import tailwindcss from "npm:tailwindcss@3.4.1";
 import { cyan } from "std/fmt/colors.ts";
 import { ensureFile } from "std/fs/mod.ts";
 import { join, toFileUrl } from "std/path/mod.ts";


### PR DESCRIPTION
This PR Integrates TailwindCSS with Decofile. 

Currently, the TailwindCSS is cached by the revision id of the current release. If the revision changes, the stylesheet is regenerated. Future work should listen for changes on Decofile and produce only diff on the tailwind stylesheet